### PR TITLE
Exclude js files from type tree (AKA be compatible with tsconfig for editors)

### DIFF
--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -65,7 +65,8 @@ TypeScriptPreprocessor.prototype.toTree = function(inputNode, inputPath, outputP
    *
    */
   var types = find(process.cwd(), {
-    include: typePaths(config).map(function(a) { return a + '/**/*'})
+    include: typePaths(config).map(function(a) { return a + '/**/*'}),
+    exclude: ["**/*.js"]
   });
 
   /*


### PR DESCRIPTION
In order to allow editors to resolve modules it is necessary to set additional paths in `tsconfig.json` (see #4)

These files leak past the TypeScript source tree via the type tree and prevent the TypeScript Compiler from writing the compiled files as a file already exists with the same name. This change  adds a filter on the type tree to stop this leak