### PR TITLE
Add additional config declarations

### DIFF
--- a/blueprints/ember-cli-typescript/files/app/config/environment.d.ts
+++ b/blueprints/ember-cli-typescript/files/app/config/environment.d.ts
@@ -9,4 +9,7 @@ export default config;
  */
 declare namespace config {
   export var environment: any;
+  export var modulePrefix: String;
+  export var podModulePrefix: String;
+  export var locationType: String;
 }


### PR DESCRIPTION
Using default app.js from ember-cli generator declares these properties, which raise warnings in Typescript.

I'm brand new to typescript, so I'm not really sure this is the way to solve this, so take this PR with a grain of salt.