### PR TITLE
'string' not 'String'

### DIFF
--- a/blueprints/ember-cli-typescript/files/app/config/environment.d.ts
+++ b/blueprints/ember-cli-typescript/files/app/config/environment.d.ts
@@ -9,7 +9,7 @@ export default config;
  */
 declare namespace config {
   export var environment: any;
-  export var modulePrefix: String;
-  export var podModulePrefix: String;
-  export var locationType: String;
+  export var modulePrefix: string;
+  export var podModulePrefix: string;
+  export var locationType: string;
 }


### PR DESCRIPTION
'String' is for "non-primitive boxed objects".