### PR TITLE
Fix reloading of tmp directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ ember install ember-cli-typescript
 
 All dependencies will be added to your package.json, and you're ready to roll!
 
-## Configuration file
+## Configuration file notes
 
+If you make changes to the paths included in your `tsconfig.json`, you will need to restart the server to take the changes into account.
 
 ### Problem ###
 
-The configuration file is used by both Ember
-CLI/[broccoli](http://broccolijs.com/) and [VS
-Code](http://code.visualstudio.com/)/`tsc` command line compiler.
+The configuration file is used by both Ember CLI/[broccoli](http://broccolijs.com/) and [VS Code](http://code.visualstudio.com/)/`tsc` command line compiler.
 
 Broccoli controls the inputs and the output folder of the various build steps
 that make the Ember build pipeline. Its expectation are impacted by Typescript

--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -7,6 +7,7 @@ const Funnel = require("broccoli-funnel");
 const MergeTrees = require("broccoli-merge-trees");
 const ts = require('typescript');
 const tsc = require('broccoli-typescript-compiler').typescript;
+const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
 function readConfig(configFile) {
   const result = ts.readConfigFile(configFile, ts.sys.readFile);
@@ -57,20 +58,22 @@ class TypeScriptPreprocessor {
 
     // The `include` setting is meant for the IDE integration; broccoli manages
     // manages its own input files.
-    tsconfig.include = ["**/*"];
+    tsconfig.include = ["**/*.ts"];
 
     // tsc needs to emit files on the broccoli pipeline, but not in the default
     // config. Otherwise its compiled `.js` files may be created inadvertently.
     tsconfig.compilerOptions.noEmit = false;
-    if (tsconfig.compilerOptions.outDir) {
-      delete tsconfig.compilerOptions.outDir;
-    }
+    delete tsconfig.compilerOptions.outDir;
 
     // Create a funnel with the type files used by the typescript compiler.
-    const types = find(process.cwd(), {
-      include: typePaths(tsconfig).map(a => `${a}/**/*`),
-      exclude: ["**/*.js"]
+    // These will change infrequently (read: usually not at all) so grab each as
+    // an *unwatched* directory, and return it at the proper location.
+    const typeTrees = typePaths(tsconfig).map((typePath) => {
+      const typeTree = new UnwatchedDir(typePath);
+      return new Funnel(typeTree, { destDir: typePath });
     });
+
+    const types = new MergeTrees(typeTrees);
 
     // Passthrough all the javascript files existing in the source/test folders.
     const passthrough = new Funnel(inputNode, {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "broccoli-funnel": "^1.0.6",
     "broccoli-merge-trees": "^1.1.4",
     "broccoli-plugin": "^1.2.1",
+    "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.4.0",
     "broccoli-typescript-compiler": "^1.0.1",
     "debug": "^2.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "allowJs": true,
+    "allowJs": false,
     "moduleResolution": "node",
     "noEmitOnError": true,
     "baseUrl": ".",


### PR DESCRIPTION
- Add `broccoli-source` dependency.
- Use `UnwatchedDir` for the root to prevent rebuilds of types.
- Update README to note that changes to `tsconfig.json` require restarting the server.
- Only pull in `.ts` files in the overwritten `include` value in the tsconfig passed to broccoli-typescript.

I believe this fixes #11. It may also helper with #19. @IceDragon200 @pixelhandler do you mind taking a look? I'll test myself later as well, but would appreciate further confirmation.