### PR TITLE
[FEATURE]: support non @types based TS type defs

### DIFF
--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -22,7 +22,7 @@ function readConfig(configFile) {
  * Return the paths which contain type information.
  */
 function typePaths(config) {
-  const base = ["node_modules/@types"];
+  const base = ["node_modules"];
 
   const cfgPaths = (config.compilerOptions && config.compilerOptions.paths) || {};
 


### PR DESCRIPTION
This is half observation / half question. I've found working outside of ember that most library authors now ship the `index.d.ts` file w/ the JS source (instead of using the definitely typed repository). This change does incur a tax today because we don't filter that types work down to only `**/*.d.ts` file types so ... in my app I had to hack a ton of modules out using exclude (not ideal)

Any chance we could expand this type defs lookup to reach the wider JS ecosystem by not zooming in on the `node_modules/@types` dir explicitly?

```js
  "exclude": [
      "node_modules/typescript/lib/**/*.ts",
      "node_modules/memory-streams/**/*.ts",
      "node_modules/ember-source/**/*.ts",
      "node_modules/@glimmer/**/*.ts",
      "node_modules/ember-cli-typescript/**/*.ts",
      "node_modules/iconv-lite/lib/**/*.ts",
      "node_modules/aot-test-generators/**/*.ts",
      "node_modules/rx/ts/**/*.ts"
  ]
```