### PR TITLE
Upgrade ember-cli and typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 2017,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    browser: true
+  },
+  rules: {
+  }
+};

--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@
 .editorconfig
 .ember-cli
 .gitignore
-.jshintrc
+.eslintrc.js
 .watchmanconfig
 .travis.yml
 bower.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
 ---
 language: node_js
 node_js:
-  - "4"
+  - "6"
 
 sudo: false
 
 cache:
-  directories:
-    - $HOME/.npm
-    - $HOME/.cache # includes bowers cache
+  yarn: true
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
@@ -17,6 +15,7 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true
@@ -24,17 +23,15 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - npm config set spin false
-  - npm install -g bower
-  - bower --version
-  - npm install phantomjs-prebuilt
-  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+  - yarn global add phantomjs-prebuilt
+  - phantomjs --version
 
 install:
-  - npm install
-  - bower install
+  - yarn install --no-lockfile
 
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,0 @@
-{
-  "name": "ember-cli-typescript",
-  "dependencies": {
-    "ember": "~2.10.0",
-    "ember-cli-shims": "0.1.3"
-  }
-}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
   scenarios: [
     {
@@ -9,6 +9,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-4'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -21,6 +26,11 @@ module.exports = {
         resolutions: {
           'ember': 'lts-2-8'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -31,6 +41,11 @@ module.exports = {
         },
         resolutions: {
           'ember': 'release'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
         }
       }
     },
@@ -43,6 +58,11 @@ module.exports = {
         resolutions: {
           'ember': 'beta'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
       }
     },
     {
@@ -54,6 +74,17 @@ module.exports = {
         resolutions: {
           'ember': 'canary'
         }
+      },
+      npm: {
+        devDependencies: {
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-default',
+      npm: {
+        devDependencies: {}
       }
     }
   ]

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,5 @@
-/*jshint node:true*/
-/* global require, module */
-var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+/* eslint-env node */
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-env node */
 
 'use strict';
 var path      = require('path');

--- a/package.json
+++ b/package.json
@@ -34,37 +34,37 @@
     "broccoli-stew": "^1.4.0",
     "broccoli-typescript-compiler": "^1.0.1",
     "debug": "^2.2.0",
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^6.3.0"
   },
   "devDependencies": {
     "@types/ember": "^2.7.34",
     "broccoli-asset-rev": "^2.4.5",
-    "ember-ajax": "^2.4.1",
-    "ember-cli": "2.10.0",
+    "ember-cli": "^2.13.3",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-htmlbars": "^1.0.10",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.3",
+    "ember-cli-eslint": "^3.0.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-jshint": "^2.0.1",
-    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-qunit": "^4.0.0",
     "ember-cli-release": "^0.2.9",
+    "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
-    "ember-resolver": "^2.0.3",
-    "loader.js": "^4.0.10",
-    "typescript": "^2.1.0"
+    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-export-application-global": "^2.0.0",
+    "ember-load-initializers": "^1.0.0",
+    "ember-resolver": "^4.0.0",
+    "ember-source": "~2.13.3",
+    "loader.js": "^4.2.3",
+    "typescript": "^2.4.1"
   },
   "peerDependencies": {
     "@types/ember": "^2.7.34",
-    "typescript": "^2.1.0"
+    "typescript": "^2.4.1"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,5 @@
-/*jshint node:true*/
+/* eslint-env node */
 module.exports = {
-  "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  env: {
+    embertest: true
+  }
+};

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-env node */
 
 module.exports = function(environment) {
   var ENV = {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,0 +1,10 @@
+/* eslint-env node */
+
+module.exports = {
+  browsers: [
+    'ie 9',
+    'last 1 Chrome versions',
+    'last 1 Firefox versions',
+    'last 1 Safari versions'
+  ]
+};

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,16 +3,13 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let application;
+  let attributes = Ember.merge({}, config.APP);
+  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  // use defaults, but you can override
-  let attributes = Ember.assign({}, config.APP, attrs);
-
-  Ember.run(() => {
-    application = Application.create(attributes);
+  return Ember.run(() => {
+    let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
+    return application;
   });
-
-  return application;
 }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,7 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);
+start();


### PR DESCRIPTION
This PR update ember-cli to 2.13.3 and updates typescript to 2.4.1

Was useful for some things that I'm working on, may be useful to you folks too.