### PR TITLE
fix error transpiling referenced javascript files

### DIFF
--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -20,6 +20,7 @@ class TypeScriptPreprocessor {
     // includes, always emit, and let Broccoli manage any outDir.
     this.config = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'tsconfig.json')));
     this.config.compilerOptions.noEmit = false;
+    this.config.compilerOptions.allowJs = false;
     delete this.config.compilerOptions.outDir;
     delete this.config.include;
   }


### PR DESCRIPTION
When referencing a .js from .ts:
```
  // service.ts
  import User from './user.js';
```
This error will occur:
```
  error TS5055: Cannot write file './user.js' because it would overwrite input file.
```