### PR TITLE
add in-repo-addons to generated tsconfig.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@
 bower.json
 ember-cli-build.js
 testem.js
+node-tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - yarn run nodetest
 
 # We build PRs, but don't trigger separate builds for the PR from the branch.
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ test_script:
   # Output useful info for debugging.
   - yarn versions
   - cmd: yarn run test
+  - cmd: yarn run nodetest
 
 # Don't actually build.
 build: off

--- a/blueprints/ember-cli-typescript/files/tsconfig.json
+++ b/blueprints/ember-cli-typescript/files/tsconfig.json
@@ -9,7 +9,12 @@
     "baseUrl": ".",
     "paths": {
       "<%= dasherizedPackageName %>/tests/*": ["tests/*"],
-      "<%= dasherizedPackageName %>/*": ["app/*"]
+      "<%= dasherizedPackageName %>/*": [
+        "app/*"<%
+inRepoAddons.forEach(function(path) { %>,
+        "<%= path %>/app/*"<%
+}) %>
+      ]
     }
   },
   "exclude": [

--- a/blueprints/ember-cli-typescript/index.js
+++ b/blueprints/ember-cli-typescript/index.js
@@ -26,6 +26,12 @@ module.exports = {
     }
   },
 
+  locals() {
+    return {
+      inRepoAddons: (this.project.pkg['ember-addon'] || {}).paths || []
+    };
+  },
+
   normalizeEntityName() {
     // Entity name is optional right now, creating this hook avoids an error.
   },

--- a/node-tests/blueprints/ember-cli-typescript-test.js
+++ b/node-tests/blueprints/ember-cli-typescript-test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  setupTestHooks,
+  emberNew,
+  emberGenerate
+} = require('ember-cli-blueprint-test-helpers/helpers');
+const { expect, file } = require('ember-cli-blueprint-test-helpers/chai');
+
+describe('Acceptance: ember-cli-typescript generator', function() {
+  setupTestHooks(this);
+
+  it('basic app', function() {
+    const args = ['ember-cli-typescript'];
+
+    return emberNew()
+      .then(() => emberGenerate(args))
+      .then(() => {
+        const tsconfig = file('tsconfig.json');
+        expect(tsconfig).to.exist;
+
+        const json = JSON.parse(tsconfig.content);
+        expect(json.compilerOptions.paths).to.deep.equal({
+          'my-app/tests/*': [ 'tests/*' ],
+          'my-app/*': [ 'app/*' ]
+        });
+    });
+  });
+
+  it('in-repo addons', function() {
+    const args = ['ember-cli-typescript'];
+
+    return emberNew()
+      .then(() => {
+        const packagePath = path.resolve(process.cwd(), 'package.json');
+        const contents = JSON.parse(fs.readFileSync(packagePath, { encoding: 'utf8' }));
+        contents['ember-addon'] = {
+          paths: [
+            'lib/my-addon-1',
+            'lib/my-addon-2'
+          ]
+        };
+        fs.writeFileSync(packagePath, JSON.stringify(contents, null, 2));
+      })
+      .then(() => emberGenerate(args))
+      .then(() => {
+        const tsconfig = file('tsconfig.json');
+        expect(tsconfig).to.exist;
+
+        const json = JSON.parse(tsconfig.content);
+        expect(json.compilerOptions.paths).to.deep.equal({
+          'my-app/tests/*': [ 'tests/*' ],
+          'my-app/*': [
+            'app/*',
+            'lib/my-addon-1/app/*',
+            'lib/my-addon-2/app/*',
+          ]
+        });
+      });
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each",
+    "nodetest": "mocha node-tests --recursive"
   },
   "dependencies": {
     "broccoli-debug": "^0.6.3",
@@ -43,6 +44,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "^2.13.3",
     "ember-cli-app-version": "^2.0.0",
+    "ember-cli-blueprint-test-helpers": "^0.17.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.1.1",
@@ -59,6 +61,7 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.13.3",
     "loader.js": "^4.2.3",
+    "mocha": "^2.2.1",
     "typescript": "^2.4.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Adds path for in-repo-addons / engines, for example:
```json
{
  "compilerOptions": {
    ...
    "paths": {
      "web/tests/*": ["tests/*"],
      "web/*": [
        "app/*",
        "lib/in-repo-addon-1/app/*",
        "lib/in-repo-addon-2/app/*"
      ]
    }
  }
}
```

I also added some tests for it