### PR TITLE
Add file extension to preprocessor

### DIFF
--- a/lib/typescript-preprocessor.js
+++ b/lib/typescript-preprocessor.js
@@ -15,6 +15,7 @@ class TypeScriptPreprocessor {
   constructor(options) {
     this.name = 'ember-cli-typescript';
     this._tag = tag++;
+    this.ext = 'ts';
 
     // Update the config for how Broccoli handles the file system: no need for
     // includes, always emit, and let Broccoli manage any outDir.


### PR DESCRIPTION
After learning way more about the internals of broccoli and ember-cli than I'd expected to today ...

Using broccoli-stew to print out the `inputNode` in `toTree`, I noticed that it was being passed 

```js
include: [/js$/]
``` 

This seems to only be the case for the `addon` directory, which is why I think it wasn't breaking in 'normal' app usage.  The `toTree` hook gets called three times (addon, app and tests).  The tree received when invoked by `app` is quite different to the one from `addon`.

After digging around I noticed in here https://ember-cli.com/api/classes/Addon.html#method_setupPreprocessorRegistry that the file extension is used to determine the tree that the preProcessor receives.

Adding the extension to the `TypeScriptPreprocessor` changes it to this

```js
include: [/js$/, /ts$/]
```

Which results in the typescript files being correctly passed to the tsc compiler.

